### PR TITLE
Remove multi browser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 dist
 .vscode
 node_modules
+.VSCodeCounter

--- a/src/RHI-local.ts
+++ b/src/RHI-local.ts
@@ -4,15 +4,8 @@ import puppeteer from "puppeteer";
 import main from "./lambda/RHI/main";
 import { PuppeteerNode as PuppeteerCoreNode } from "puppeteer-core";
 
-import {
-    loginsTable,
-    ExistingRecord,
-    LoginInput,
-    getAllRecords,
-} from "./lambda/globals";
-
 const browserArgs = {
-    headless: "new", //using new headless mode, set to false to disable headless
+    headless: false, //"new", //using new headless mode, set to false to disable headless
     defaultViewport: null,
     args: [
         "--autoplay-policy=user-gesture-required",
@@ -61,8 +54,7 @@ const browserArgs = {
     await main([{ loginID: "65e37da7f8428f036fd9999a" }],
         puppeteer as unknown as PuppeteerCoreNode,
         browserArgs,
-        1,
-        true);
+        false);
     return;
     /* */
 

--- a/src/lambda/RHI/main.ts
+++ b/src/lambda/RHI/main.ts
@@ -8,7 +8,6 @@ import {
 import { RHIRecord } from "../globals";
 import { HTTPError } from "../globals";
 import { getRecordsByFieldValues } from "../globals";
-import { LoginInput, AccountInput, RHIInput } from "../globals";
 import { ExistingRecord } from "../globals";
 import { SMARTSUITE_HEADERS } from "../globals";
 import { getAllRecords } from "../globals";
@@ -19,234 +18,187 @@ import validateLogin from "./validateLogin";
 import getRHIDetails from "./getRHIDetails";
 import { PuppeteerNode as PuppeteerCoreNode } from "puppeteer-core";
 
-type Inputs = LoginInput[] | AccountInput[] | RHIInput[];
-
-const MIN_LOGINS_PER_BROWSER = 3;
+type Inputs = { loginID: string }[];
 
 export default async function main(
     inputs: Inputs,
     puppeteer: PuppeteerCoreNode,
     browserArgs: object,
-    multiplicity: number = 1,
-    shallow: boolean = false
+    shallow: boolean = false //can be set to true to skip over some information checking to improve performance
 ) {
     if (inputs.length === 0) throw new Error("Empty input array");
+    if (!("loginID" in inputs[0])) throw new Error("No loginID in first input"); //check for correct format
 
-    if ("loginID" in inputs[0]) {
-        //if triggered with login IDs to update
+    //get login records from login table
+    const loginRecordsList: LoginRecord[] = await getRecordsByFieldValues(
+        (inputs).map((input) => input.loginID),
+        loginsTable.fields["Record ID (System Field)"],
+        loginsTable.id
+    );
 
-        //get login records from login table
-        const loginRecordsList: ExistingRecord[] = await getRecordsByFieldValues(
-            (inputs as LoginInput[]).map((input: LoginInput) => input.loginID),
-            loginsTable.fields["Record ID (System Field)"],
-            loginsTable.id
+    //parse login records as dictionary with record IDs as keys
+    const loginRecords: Record<string, LoginRecord> = {};
+    for (const loginRecord of loginRecordsList) {
+        loginRecords[loginRecord.id] = loginRecord;
+    }
+
+    //get RHI Records from RHI Table
+    const ExistingRHIRecords = {};
+    const ExistingRHIAccounts = {};
+    (await getAllRecords(RHIsTable.id)).forEach((RHI) => {
+        ExistingRHIRecords[RHI.title] = RHI.id;
+        ExistingRHIAccounts[RHI.title] = RHI[RHIsTable.fields["RHI Account"]];
+    });
+    const browser = await puppeteer.launch(browserArgs);
+
+    const loginIDs = inputs.map(
+        (inputLogin) => inputLogin.loginID
+    );
+    const loginDetails: LoginRecord[] = [];
+    const accountDetails: (AccountRecord | Omit<AccountRecord, "id">)[] = [];
+    const updatedRHIDetails: RHIRecord[] = [];
+    const newRHIDetails: Omit<RHIRecord, "id">[] = [];
+    const page = await browser.newPage();
+
+    for (const loginRecordID of loginIDs) {
+        const loginRecordToUpdate: LoginRecord =
+            loginRecords[loginRecordID];
+        // set the account via updating the account record, not the login record itself
+        const accountID =
+            (loginRecordToUpdate[loginsTable.fields["Account"]] as string[])[0];
+        //delete loginRecordToUpdate[loginsTable.fields['Account']];
+
+        if (!loginRecordToUpdate[loginsTable.fields["Password Correct"]])
+            continue;
+
+        await logInUser(loginRecordToUpdate, page);
+
+        if (!(await validateLogin(page))) {
+            updateSingleRecord(
+                { [loginsTable.fields["Password Correct"]]: false },
+                loginRecordID,
+                loginsTable.id
+            );
+            console.log(
+                `Log in failed for ${loginRecordToUpdate[loginsTable.fields["Username"]]
+                }`
+            );
+            continue;
+        }
+        console.log(
+            `Log in success for ${loginRecordToUpdate[loginsTable.fields["Username"]]
+            }`
         );
 
-        const loginRecords = {};
-        for (const loginRecord of loginRecordsList) {
-            loginRecords[loginRecord.id] = loginRecord as ExistingRecord;
+        const updatedLoginRecord: LoginRecord = await getLoginDetails(
+            loginRecordToUpdate,
+            page
+        );
+
+        // Account information not available on AU logins
+        if (
+            updatedLoginRecord[loginsTable.fields["Login Type"]] ===
+            "Additional User"
+        ) {
+            const RHIDetails = await getRHIDetails(accountID, page, shallow);
+            if (!RHIDetails[0]) continue;
+
+            updatedLoginRecord[loginsTable.fields["Account"]] =
+                ExistingRHIAccounts[
+                RHIDetails[0].title as string
+                ]; // Set account using linked RHIs
+
+            RHIDetails.forEach((RHI) => {
+                delete RHI[RHIsTable.fields["RHI Account"]];
+
+                if (!(RHI.title as string in ExistingRHIRecords)) {
+                    return; //don't add RHIs that we don't have an AS password for
+                }
+                RHI.id = ExistingRHIRecords[RHI.title as string];
+                updatedRHIDetails.push(RHI); //update everything but account
+            });
+
+            loginDetails.push(updatedLoginRecord);
+            continue;
         }
 
-        //get RHI Records from RHI Table
-        const ExistingRHIRecords = {};
-        const ExistingRHIAccounts = {};
-        (await getAllRecords(RHIsTable.id)).forEach((RHI) => {
-            ExistingRHIRecords[RHI.title] = RHI.id;
-            ExistingRHIAccounts[RHI.title] = RHI[RHIsTable.fields["RHI Account"]];
-        });
+        const accountRecordToUpdate: AccountRecord | Omit<AccountRecord, "id"> = accountID ?
+            { id: accountID, } : {
+                //only update the linked login if account is brand new,
+                // i.e. corresponds to a new AS login
+                id: undefined,
+                [accountsTable.fields["Logins"]]: [loginRecordToUpdate.id],
+            };
+        /*AU logins have to be linked to pre-existing accounts on SS. That's because the account details
+                  aren't available from AU logins, so the account has to be identified via the RHIs.
+       
+                  That means that AU logins are added to an account via updating the login record, whereas AS
+                  logins are only ever added to a brand new account record via creating the record with
+                  a link to the login. Accounts records are only ever updated from an AS login.
+       
+                  That in turn means that logins have to be updated BEFORE new accounts are created, and that 
+                  updating an account record can not update the linked logins.
+                  This avoids overwriting information.*/
 
-        // use multiplicity for number of browser unless there are too few logins
-        const numBrowsers =
-            loginRecordsList.length > multiplicity * MIN_LOGINS_PER_BROWSER
-                ? multiplicity
-                : Math.floor(loginRecordsList.length / MIN_LOGINS_PER_BROWSER) || 1;
-
-        const browsers = new Array(numBrowsers).fill(
-            await puppeteer.launch(browserArgs)
+        const updatedAccountRecord: Omit<AccountRecord, "id"> = await getAccountDetails(
+            accountRecordToUpdate,
+            page
         );
-        const loginsIDsForBrowsers = splitArrayIntoSubArrays(inputs, numBrowsers);
 
-        const [
-            {
-                logins: loginDetails,
-                accounts: accountDetails,
-                newRHIs: newRHIDetails,
-                updatedRHIs: updatedRHIDetails,
-            },
-        ] = (
-            await Promise.all(
-                browsers.map(async function (browser, index) {
-                    const loginIDs = loginsIDsForBrowsers[index].map(
-                        (inputLogin: LoginInput) => inputLogin.loginID
-                    );
-                    const _updatedLoginDetails: LoginRecord[] = [];
-                    const _updatedAccountDetails: (AccountRecord | Omit<AccountRecord, "id">)[] = [];
-                    const _updatedRHIDetails: RHIRecord[] = [];
-                    const _newRHIDetails: Omit<RHIRecord, "id">[] = [];
-                    const page = await browser.newPage();
-
-                    for (const loginRecordID of loginIDs) {
-                        const loginRecordToUpdate: LoginRecord =
-                            loginRecords[loginRecordID];
-                        // set the account via updating the account record, not the login record itself
-                        const accountID =
-                            (loginRecordToUpdate[loginsTable.fields["Account"]] as string[])[0];
-                        //delete loginRecordToUpdate[loginsTable.fields['Account']];
-
-                        if (!loginRecordToUpdate[loginsTable.fields["Password Correct"]])
-                            continue;
-
-                        await logInUser(loginRecordToUpdate, page);
-
-                        if (!(await validateLogin(page))) {
-                            updateSingleRecord(
-                                { [loginsTable.fields["Password Correct"]]: false },
-                                loginRecordID,
-                                loginsTable.id
-                            );
-                            console.log(
-                                `Log in failed for ${loginRecordToUpdate[loginsTable.fields["Username"]]
-                                }`
-                            );
-                            continue;
-                        }
-                        console.log(
-                            `Log in success for ${loginRecordToUpdate[loginsTable.fields["Username"]]
-                            }`
-                        );
-
-                        const updatedLoginRecord: LoginRecord = await getLoginDetails(
-                            loginRecordToUpdate,
-                            page
-                        );
-
-                        // Account information not available on AU logins
-                        if (
-                            updatedLoginRecord[loginsTable.fields["Login Type"]] ===
-                            "Additional User"
-                        ) {
-                            const RHIDetails = await getRHIDetails(accountID, page, shallow);
-                            if (!RHIDetails[0]) continue;
-
-                            updatedLoginRecord[loginsTable.fields["Account"]] =
-                                ExistingRHIAccounts[
-                                RHIDetails[0].title as string
-                                ]; // Set account using linked RHIs
-
-                            RHIDetails.forEach((RHI) => {
-                                delete RHI[RHIsTable.fields["RHI Account"]];
-
-                                if (!(RHI.title as string in ExistingRHIRecords)) {
-                                    return; //don't add RHIs that we don't have an AS password for
-                                }
-                                RHI.id = ExistingRHIRecords[RHI.title as string];
-                                _updatedRHIDetails.push(RHI); //update everything but account
-                            });
-
-                            _updatedLoginDetails.push(updatedLoginRecord);
-                            continue;
-                        }
-
-                        const accountRecordToUpdate: AccountRecord | Omit<AccountRecord, "id"> = accountID ?
-                            { id: accountID, } : {
-                                //only update the linked login if account is brand new,
-                                // i.e. corresponds to a new AS login
-                                id: undefined,
-                                [accountsTable.fields["Logins"]]: [loginRecordToUpdate.id],
-                            };
-                        /*AU logins have to be linked to pre-existing accounts on SS. That's because the account details
-                           aren't available from AU logins, so the account has to be identified via the RHIs.
-                
-                           That means that AU logins are added to an account via updating the login record, whereas AS
-                           logins are only ever added to a brand new account record via creating the record with
-                           a link to the login. Accounts records are only ever updated from an AS login.
-                
-                           That in turn means that logins have to be updated BEFORE new accounts are created, and that 
-                           updating an account record can not update the linked logins.
-                           This avoids overwriting information.*/
-
-                        const updatedAccountRecord: Omit<AccountRecord, "id"> = await getAccountDetails(
-                            accountRecordToUpdate,
-                            page
-                        );
-
-                        if (accountID) {
-                            //only get RHIs for accounts on record
-                            const RHIDetails = await getRHIDetails(accountID, page, shallow);
-                            RHIDetails.forEach((RHI) => {
-                                if (!(RHI.title as string in ExistingRHIRecords)) {
-                                    _newRHIDetails.push(RHI);
-                                    return;
-                                }
-                                RHI.id = ExistingRHIRecords[RHI.title as string];
-                                _updatedRHIDetails.push(RHI);
-                            });
-                        }
-                        _updatedLoginDetails.push(updatedLoginRecord);
-                        _updatedAccountDetails.push(updatedAccountRecord);
-                    }
-                    await browser.close();
-                    console.log("browser closed");
-                    return {
-                        logins: _updatedLoginDetails,
-                        accounts: _updatedAccountDetails,
-                        updatedRHIs: _updatedRHIDetails,
-                        newRHIs: _newRHIDetails,
-                    };
-                })
-            )
-        )
-            .flat()
-            .filter(Boolean);
-
-        if (loginDetails.length == 0) return;
-
-        const newAccountDetails: Omit<AccountRecord, "id">[] = accountDetails
-            .filter((account) => !account.id)
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            .map(({ id, ...rest }) => rest);
-
-        const updatedAccountDetails: AccountRecord[] = accountDetails.filter(
-            (account) => !!account.id
-        ) as AccountRecord[];
-
-        //update SmartSuite logins first to avoid overwriting links to new accounts
-        if (loginDetails.length > 0)
-            updateMultipleRecords(loginDetails, loginsTable.id);
-
-        //add new accounts
-        if (newAccountDetails.length > 0)
-            await addNewRecords(newAccountDetails, accountsTable.id);
-
-        //update existing accounts
-        if (updatedAccountDetails.length > 0)
-            await updateMultipleRecords(updatedAccountDetails, accountsTable.id);
-
-        //update existing RHIs
-        if (updatedRHIDetails.length > 0)
-            await updateMultipleRecords(updatedRHIDetails, RHIsTable.id);
-
-        //add new RHIs
-        if (newRHIDetails.length > 0)
-            await addNewRecords(newRHIDetails, RHIsTable.id);
-
-        console.log("records updated");
-    } else if ("accountID" in inputs[0]) {
-        //do stuff with account
-    } else if ("rhiID" in inputs[0]) {
-        //do stuff with RHI
+        if (accountID) {
+            //only get RHIs for accounts on record
+            const RHIDetails = await getRHIDetails(accountID, page, shallow);
+            RHIDetails.forEach((RHI) => {
+                if (!(RHI.title as string in ExistingRHIRecords)) {
+                    newRHIDetails.push(RHI);
+                    return;
+                }
+                RHI.id = ExistingRHIRecords[RHI.title as string];
+                updatedRHIDetails.push(RHI);
+            });
+        }
+        loginDetails.push(updatedLoginRecord);
+        accountDetails.push(updatedAccountRecord);
     }
 
+    await browser.close();
+    console.log("browser closed");
+
+
+    if (loginDetails.length == 0) return;
+
+    const newAccountDetails: Omit<AccountRecord, "id">[] = accountDetails
+        .filter((account) => !account.id)
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        .map(({ id, ...rest }) => rest);
+
+    const updatedAccountDetails: AccountRecord[] = accountDetails.filter(
+        (account) => !!account.id
+    ) as AccountRecord[];
+
+    //update SmartSuite logins first to avoid overwriting links to new accounts
+    if (loginDetails.length > 0)
+        updateMultipleRecords(loginDetails, loginsTable.id);
+
+    //add new accounts
+    if (newAccountDetails.length > 0)
+        await addNewRecords(newAccountDetails, accountsTable.id);
+
+    //update existing accounts
+    if (updatedAccountDetails.length > 0)
+        await updateMultipleRecords(updatedAccountDetails, accountsTable.id);
+
+    //update existing RHIs
+    if (updatedRHIDetails.length > 0)
+        await updateMultipleRecords(updatedRHIDetails, RHIsTable.id);
+
+    //add new RHIs
+    if (newRHIDetails.length > 0)
+        await addNewRecords(newRHIDetails, RHIsTable.id);
+
+    console.log("records updated");
 }
 
-function splitArrayIntoSubArrays(array: unknown[], numSubArrays: number) {
-    const subArrays = new Array(numSubArrays).fill([]);
-    const length = array.length;
-    for (let i = 0; i < length; i++) {
-        subArrays[i % numSubArrays].push(array[i]);
-    }
-    return subArrays;
-}
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 async function getRecordsByTitle(titles: string[], tableID: string) {

--- a/src/lambda/index.ts
+++ b/src/lambda/index.ts
@@ -23,7 +23,7 @@ const handler: Handler = async (event) => {
                 "https://github.com/Sparticuz/chromium/releases/download/v119.0.2/chromium-v119.0.2-pack.tar",
             ),
             headless: chromium.headless,
-        }, 1, shallow);
+        }, shallow);
 
         const response = {
             statusCode: 200,


### PR DESCRIPTION
Remove support for running multiple puppeteer instances in parallel, because this 
1. Does not work in its current state
2. Will require a caching process to be implemented for all API requests to avoid rate limiting